### PR TITLE
DetailsInstallReceiver: fix null check in onReceive()

### DIFF
--- a/app/src/main/java/com/github/yeriomin/yalpstore/DetailsInstallReceiver.java
+++ b/app/src/main/java/com/github/yeriomin/yalpstore/DetailsInstallReceiver.java
@@ -5,6 +5,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.net.Uri;
 import android.os.Build;
 import android.text.TextUtils;
 
@@ -36,7 +37,8 @@ public class DetailsInstallReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        if (null == intent.getData() || !TextUtils.equals(packageName, intent.getData().getSchemeSpecificPart())) {
+        Uri intentData = intent.getData();
+        if (null == intentData || !TextUtils.equals(packageName, intentData.getSchemeSpecificPart())) {
             return;
         }
         GlobalInstallReceiver.updateDetails(GlobalInstallReceiver.actionIsInstall(intent));


### PR DESCRIPTION
```
java.lang.RuntimeException: Error receiving broadcast Intent { act=ACTION_PACKAGE_REPLACED_NON_SYSTEM flg=0x10 } in com.github.yeriomin.yalpstore.DetailsInstallReceiver@8e5cdc1
	at android.app.LoadedApk$ReceiverDispatcher$Args.run(LoadedApk.java:1132)
	at android.os.Handler.handleCallback(Handler.java:751)
	at android.os.Handler.dispatchMessage(Handler.java:95)
	at android.os.Looper.loop(Looper.java:154)
	at android.app.ActivityThread.main(ActivityThread.java:6186)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:889)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:779)
	at de.robv.android.xposed.XposedBridge.main(XposedBridge.java:107)
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String android.net.Uri.getSchemeSpecificPart()' on a null object reference
	at com.github.yeriomin.yalpstore.DetailsInstallReceiver.onReceive(DetailsInstallReceiver.java:38)
	at android.app.LoadedApk$ReceiverDispatcher$Args.run(LoadedApk.java:1122)
	... 8 more
```