### PR TITLE
bump to VC 46 for f-droid build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ android {
         applicationId "com.github.yeriomin.yalpstore"
         minSdkVersion 5
         targetSdkVersion 28
-        versionCode 45
+        versionCode 46
         versionName getVersionName()
         vectorDrawables.useSupportLibrary = true
         resConfigs "ar", "ast", "bg", "cs", "de", "el", "en", "es", "eu", "fr", "fr-rBE", "in", "it", "ja", "kk", "ko", "nl", "pl", "pt", "pt-rBR", "ru", "sk", "uk", "zh", "zh-rTW"


### PR DESCRIPTION
This is mainly a reminder that VC 46 is 'burned' because I've just used it on f-droid to work around the non-installable version: https://github.com/yeriomin/YalpStore/issues/543#issuecomment-431344739

(No need to really merge this, the f-droid build is independent from this PR - https://gitlab.com/fdroid/fdroiddata/blob/master/metadata/com.github.yeriomin.yalpstore.yml#L366)