### PR TITLE
Fix bug: AppListActivity: progress is shown in the wrong apps when scrolling

### DIFF
--- a/app/src/main/java/com/github/yeriomin/yalpstore/ListAdapter.java
+++ b/app/src/main/java/com/github/yeriomin/yalpstore/ListAdapter.java
@@ -28,15 +28,20 @@ import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.widget.ArrayAdapter;
 
+import com.github.yeriomin.yalpstore.view.AppBadge;
 import com.github.yeriomin.yalpstore.view.ListItem;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 public class ListAdapter extends ArrayAdapter<ListItem> {
 
     private int resourceId;
     private LayoutInflater inflater;
     private Animation removeAnimation;
+
+    private Map<View, ListItem> viewToListItem = new HashMap<>();
 
     public ListAdapter(Context context, int resourceId) {
         super(context, resourceId);
@@ -50,7 +55,12 @@ public class ListAdapter extends ArrayAdapter<ListItem> {
         View view = null == convertView ? inflater.inflate(resourceId, parent, false) : convertView;
         ListItem listItem = getItem(position);
         if (null != listItem && null != view) {
+            ListItem oldItemForThisView = viewToListItem.get(view);
+            if (oldItemForThisView != null) {
+                oldItemForThisView.setView(null);
+            }
             listItem.setView(view);
+            viewToListItem.put(view, listItem);
             listItem.draw();
         }
         return view;
@@ -75,6 +85,14 @@ public class ListAdapter extends ArrayAdapter<ListItem> {
         if (null == listItem || null == listItem.getView()) {
             return;
         }
+
+        if (listItem instanceof AppBadge) {
+            if (viewToListItem.get(listItem.getView()) != listItem) {
+                listItem.setView(null);
+                return;
+            }
+        }
+
         removeAnimation.setAnimationListener(new Animation.AnimationListener() {
             @Override
             public void onAnimationStart(Animation animation) {


### PR DESCRIPTION
**Problem**
On the search result screen, when starting an app download and scrolling down the results list, the download progress indicator will appear on other apps.

**Cause**
`ListItem` has a reference to its `View`, but this reference is not updated when that view is used to render a different `ListItem`.

**Solution**
Keep note of the latest `ListItem` for each `View` in `ListAdapter`, and when that `View` has switched to render a different `ListItem`, update the previous `ListItem`'s reference with `null`.